### PR TITLE
[FEAT] Adding Dockerfile and github action for continuous deployment to Azure

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -1,0 +1,44 @@
+on: 
+  push:
+    branches:
+      - main
+
+name: deploy container to azure web app
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    # checkout the repo
+    - name: 'Checkout GitHub Action' 
+      uses: actions/checkout@main
+    
+    # login to azure within the github action
+    - name: 'Login via Azure CLI'
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+    
+    # login to the private container registry
+    # build the docker container
+    # push the newest version to the container registry
+    - uses: azure/docker-login@v1
+      with:
+        login-server: gbmdeconvoluter.azurecr.io
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+    - run: |
+        docker build . -t gbmdeconvoluter.azurecr.io/gbmconvoluter:${{ github.sha }}
+        docker push gbmdeconvoluter.azurecr.io/gbmconvoluter:${{ github.sha }}     
+      
+    # deploy the newest container image 
+    # to the azure web app
+    - uses: azure/webapps-deploy@v2
+      with:
+        app-name: 'gbmdeconvoluter'
+        images: 'gbmdeconvoluter.azurecr.io/gbmconvoluter:${{ github.sha }}'
+    
+    # logout from azure
+    - name: Azure logout
+      run: |
+        az logout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Install R version 3.5
+FROM rocker/shiny:latest
+
+# Install Ubuntu packages
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    libssl-dev \
+    libxml2-dev
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean
+
+# Copy configuration files into the Docker image
+COPY ./renv.lock ./renv.lock
+
+# install renv & restore packages
+RUN Rscript -e 'install.packages("renv")'
+RUN Rscript -e 'renv::restore()'
+
+COPY . /srv/shiny-server
+
+USER shiny
+
+EXPOSE 3838

--- a/deploy-notes.sh
+++ b/deploy-notes.sh
@@ -1,0 +1,23 @@
+# this is a rough and ready bash script with steps used to build 
+# push this container to the private azure container registry
+
+# here we run docker build to create the container image
+# using the dockerfile specified in the current directory
+# we give it a name and a tag with the format name:tag
+docker build . -t gbmconvoluter:2022-08-02
+
+# once built this image is available locally
+# we can run a container instance of the image with
+# docker run --rm -p 3838:3838 gbmconvoluter:2022-08-02
+
+# next we use docker login to connect to our private registry
+docker login gbmdeconvoluter.azurecr.io
+# this will prompt for a password and username available on Azure
+
+# now we create a new tag of the docker image pointing it at the container registry
+docker tag gbmconvoluter:2022-08-02 gbmdeconvoluter.azurecr.io/gbmconvoluter:2022-08-02
+
+# once retagged we can push the image from our machine to the registry
+docker push gbmdeconvoluter.azurecr.io/gbmconvoluter:2022-08-02
+
+# the docker image is now available in the private container registry on azure


### PR DESCRIPTION
This PR adds a number of components for helping deploy this tool as an [Azure App Service](https://azure.microsoft.com/en-gb/services/app-service/). In particular, a Dockerfile for containerization and a GitHub action workflow file for adding continuous deployment.

This repository is now deployed to Azure at https://gbmdeconvoluter.azurewebsites.net/. This is as a dockerized shiny application with a private Azure container registry containing Docker images of the application that are pulled into the running Azure app service session.

Included changes:
- Added a Dockerfile, this allows for the building of a docker image based on this repository
- A `deploy-notes.sh` file, this contains some notes about steps taken for the initial building and pushing of the Docker image to the private container registry (but not deployment of the Azure app service)
- A GitHub action workflow based off [Microsoft Docs](https://docs.microsoft.com/en-us/azure/app-service/deploy-github-actions). Additions have been made to account for the specific container registry used 

Notes:
For the GitHub action workflow to work we will need to set some repository secrets (**Settings > Secrets > Add a new secret.**).  I will provide these via email/Teams.